### PR TITLE
Update TargetFramework to net6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a generator to create a class-diagram of PlantUML from the C# source cod
 Nuget Gallery: https://www.nuget.org/packages/PlantUmlClassDiagramGenerator
 
 ### Installation
-Download and install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/windows) or newer. Once installed, run the following command.
+Download and install the [.NET 6.0 SDK](https://www.microsoft.com/net/download/windows) or newer. Once installed, run the following command.
 
 ```bat
 dotnet tool install --global PlantUmlClassDiagramGenerator

--- a/src/PlantUmlClassDiagramGenerator.Library/PlantUmlClassDiagramGenerator.Library.csproj
+++ b/src/PlantUmlClassDiagramGenerator.Library/PlantUmlClassDiagramGenerator.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PlantUmlClassDiagramGenerator/PlantUmlClassDiagramGenerator.csproj
+++ b/src/PlantUmlClassDiagramGenerator/PlantUmlClassDiagramGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>puml-gen</ToolCommandName>
     <Description>This is a generator to create a class-diagram of PlantUML from the C# source code.</Description>

--- a/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
+++ b/test/PlantUmlClassDiagramGeneratorTest/PlantUmlClassDiagramGeneratorTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR updates the TargetFramework to net6.0, in order to make the PlantUmlDiagramGenerator usable without net5.0.

Original PR: https://github.com/pierre3/PlantUmlClassDiagramGenerator/pull/53
Original Commit/Repo: https://github.com/chraxo/PlantUmlClassDiagramGenerator/tree/dotNet6