### PR TITLE
Fix excludePaths from skipping incorrectly

### DIFF
--- a/src/PlantUmlClassDiagramGenerator/Program.cs
+++ b/src/PlantUmlClassDiagramGenerator/Program.cs
@@ -125,11 +125,16 @@ namespace PlantUmlClassDiagramGenerator
             var pumlexclude = CombinePath(inputRoot, ".pumlexclude");
             if (File.Exists(pumlexclude))
             {
-                excludePaths = File.ReadAllLines(pumlexclude).ToList();
+                excludePaths = File
+                    .ReadAllLines(pumlexclude)
+                    .Where(path => !string.IsNullOrWhiteSpace(path))
+                    .Select(path => path.Trim())
+                    .ToList();
             }
             if (parameters.ContainsKey("-excludePaths"))
             {
-                excludePaths.AddRange(parameters["-excludePaths"].Split(','));
+                var splitOptions = StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries;
+                excludePaths.AddRange(parameters["-excludePaths"].Split(',', splitOptions));
             }
 
             var files = Directory.EnumerateFiles(inputRoot, "*.cs", SearchOption.AllDirectories);


### PR DESCRIPTION
@khalidabuhakmeh wrote:
> I was using the `.pumlexclude` file and found that any additional blank lines were being processed. This caused all files to be skipped in the `inputRoot` directory.

Original PR: https://github.com/pierre3/PlantUmlClassDiagramGenerator/pull/54
Original Repo/Commit: https://github.com/khalidabuhakmeh/PlantUmlClassDiagramGenerator/tree/fix-excludePaths